### PR TITLE
update local rust toolchain and in CI, fix lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,23 +19,39 @@ jobs:
         name: Check format
         steps:
             - uses: actions/checkout@v4
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                toolchain: stable
+                override: true
             - run: cargo fmt --check
     tests:
         runs-on: ubuntu-latest
         name: Tests
         steps:
             - uses: actions/checkout@v4
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                toolchain: stable
+                override: true
             - run: cargo test
     build:
         runs-on: ubuntu-latest
         name: Build
         steps:
             - uses: actions/checkout@v4
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                toolchain: stable
+                override: true
             - run: cargo build --verbose
     clippy:
         runs-on: ubuntu-latest
         name: Check lint
         steps:
             - uses: actions/checkout@v4
+            - uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                toolchain: stable
+                override: true
             - run: cargo clippy -- -Dwarnings
-    
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,12 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    if let Err(err) = dotenv() {
-        if !err.not_found() {
-            let err = format!("Error while loading .env file: {err}");
-            error!(err);
-            return Err(anyhow::anyhow!(err));
-        }
+    if let Err(err) = dotenv()
+        && !err.not_found()
+    {
+        let err = format!("Error while loading .env file: {err}");
+        error!(err);
+        return Err(anyhow::anyhow!(err));
     }
 
     tracing_subscriber::registry()


### PR DESCRIPTION
## Summary

Set the Rust toolchain in CI to `stable`.

Fix lint error