### PR TITLE
compare timestamp with micro seconds instead of pure seconds

### DIFF
--- a/tests/account_signup_test.rs
+++ b/tests/account_signup_test.rs
@@ -64,7 +64,7 @@ async fn test_account_signup_two_successive_times() {
     let updated_account = update_response.json::<AccountResponse>().await.unwrap();
     assert_eq!(account.created_at, updated_account.created_at);
     assert!(
-        account.updated_at.timestamp() < updated_account.updated_at.timestamp(),
+        account.updated_at.timestamp_micros() < updated_account.updated_at.timestamp_micros(),
         "{} is equal or after {}",
         account.updated_at,
         updated_account.updated_at


### PR DESCRIPTION
# Summary

Comparison of timestamps in integration test is now made using timestamp with micro seconds in order to handle updates that are too close.