### PR TITLE
implement dummy email verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,6 +2180,7 @@ dependencies = [
  "fake",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ dotenvy = "0.15.7"
 fake = { version = "4.4.0", features = ["chrono"] }
 rand = "0.9.2"
 rand_chacha = "0.9.0"
+regex = "1.11.2"
 reqwest = { version = "0.12.23", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"

--- a/src/routes/account/model.rs
+++ b/src/routes/account/model.rs
@@ -21,6 +21,11 @@ impl Account {
     pub fn update_password_hash(&mut self, password_hash: String) {
         self.password_hash = password_hash;
     }
+
+    /// Verify the email of an account
+    pub fn verify_email(&mut self) {
+        self.email_verified = true;
+    }
 }
 
 #[cfg(test)]

--- a/src/routes/account/password_strategy.rs
+++ b/src/routes/account/password_strategy.rs
@@ -1,4 +1,4 @@
-use argon2::{Argon2, PasswordHasher, password_hash::Salt};
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier, password_hash::Salt};
 use base64::prelude::*;
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
@@ -24,5 +24,17 @@ impl PasswordStrategy {
             .hash_password(password.as_bytes(), argon_salt)
             .map_err(|e| anyhow::anyhow!("{e}"))
             .map(|v| v.to_string())
+    }
+
+    /// Verify a password using the Argon2id algorithm.
+    ///
+    /// # Arguments
+    /// * `password` - Password to verify
+    /// * `hash` - Argon2id hash of the password
+    pub fn verify_password(password: &str, hash: &str) -> Result<(), anyhow::Error> {
+        let password_hash = PasswordHash::new(hash).map_err(|e| anyhow::anyhow!("{e}"))?;
+        Argon2::default()
+            .verify_password(password.as_bytes(), &password_hash)
+            .map_err(|e| anyhow::anyhow!("{e}"))
     }
 }


### PR DESCRIPTION
# Summary

The `POST /accounts/verify-email` route is implemented: it allows a signed up account to verify its email using the expected code. The code is expected as base64 and is verified against the entry in the database using a HMAC-Sha3-256. A `bad request` exception is sent if the account is already verified.