### PR TITLE
Complete email verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,11 +2197,13 @@ dependencies = [
  "chrono",
  "dotenvy",
  "fake",
+ "hmac",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "reqwest",
  "serde",
  "serde_json",
+ "sha3",
  "sqlx",
  "sqlx-cli",
  "thiserror 2.0.16",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ base64 = "0.22.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 dotenvy = "0.15.7"
 fake = { version = "4.4.0", features = ["chrono"] }
+hmac = "0.12.1"
 rand = "0.9.2"
 rand_chacha = "0.9.0"
 reqwest = { version = "0.12.23", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
+sha3 = "0.10.8"
 sqlx = { version = "0.8.6", features = ["runtime-tokio", "postgres", "uuid", "tls-rustls", "chrono"] }
 thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ pub struct Account {
         /// * `email` - Email of the account
         ///
         /// # Errors
-        /// - `Unclassified`: fallback error type
+        /// * `Unclassified` - fallback error type
         async fn get_account_by_email(
             &self,
             email: &str,
@@ -182,7 +182,7 @@ pub struct Account {
         /// * `account` - Updated account,
         ///
         /// # Errors
-        /// - `Unclassified`: fallback error type
+        /// * `Unclassified` - fallback error type
         async fn update_account(&self, account: &Account) -> Result<Account, AccountRepositoryError>;
 
         /// Create an account
@@ -192,7 +192,7 @@ pub struct Account {
         /// * `password_hash` - Hash of the password
         ///
         /// # Errors
-        /// - `Unclassified`: fallback error type
+        /// * `Unclassified` - fallback error type
         async fn create_account(
             &self,
             email: &str,

--- a/migrations/20250830101858_account.sql
+++ b/migrations/20250830101858_account.sql
@@ -15,3 +15,19 @@ CREATE TRIGGER update_account_moddatetime
 BEFORE UPDATE ON "account"
 FOR EACH ROW
 EXECUTE FUNCTION moddatetime('updated_at');
+
+CREATE TYPE verification_code_request_status AS ENUM ('active', 'cancelled', 'confirmed');
+
+CREATE TABLE IF NOT EXISTS "verification_code_request" (
+    id              UUID                                NOT NULL    PRIMARY KEY DEFAULT uuid_generate_v4 (),
+    account_id      UUID                                NOT NULL,
+    cyphertext      TEXT                                NOT NULL,
+    status          verification_code_request_status    NOT NULL    DEFAULT 'active',
+    created_at      TIMESTAMPTZ                         NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMPTZ                         NOT NULL    DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TRIGGER update_verification_code_request_moddatetime
+BEFORE UPDATE ON "verification_code_request"
+FOR EACH ROW
+EXECUTE FUNCTION moddatetime('updated_at');

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::{
 use tracing::Level;
 
 pub mod routes;
+pub mod third_party;
 
 pub struct Config {
     pub port: u16,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use dotenvy::dotenv;
 use soko::{
     Config,
     routes::{PostgresAccountRepository, app_router},
+    third_party::ToBeImplementedMailingService,
 };
 use sqlx::postgres::PgPoolOptions;
 use tokio::signal;
@@ -71,8 +72,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let x_request_id = HeaderName::from_static(REQUEST_ID_HEADER);
 
     let account_repository = PostgresAccountRepository::from(pool);
+    let mailing_service = ToBeImplementedMailingService;
 
-    let app = app_router(&config, account_repository).layer((
+    let app = app_router(&config, account_repository, mailing_service).layer((
         // Set `x-request-id` header for every request
         SetRequestIdLayer::new(x_request_id.clone(), MakeRequestUuid),
         // Log request and response

--- a/src/routes/account/mod.rs
+++ b/src/routes/account/mod.rs
@@ -126,8 +126,6 @@ async fn signup_account(
         let (code, code_cyphertext) =
             VerificationCodeStategy::generate_verification_code(&payload.email)?;
 
-        warn!("THIS LOG IS MEANT TO BE DELETED IN THE FUTURE -- Code to input is {code}");
-
         existing_account = app_state
             .account_repository
             .update_account(&existing_account)
@@ -152,8 +150,6 @@ async fn signup_account(
 
     let (code, code_cyphertext) =
         VerificationCodeStategy::generate_verification_code(&payload.email)?;
-
-    warn!("THIS LOG IS MEANT TO BE DELETED IN THE FUTURE -- Code to input is {code}");
 
     let created_account = app_state
         .account_repository

--- a/src/routes/account/model.rs
+++ b/src/routes/account/model.rs
@@ -141,10 +141,14 @@ mod tests {
     #[test]
     fn test_verification_request_expiration() {
         let mut verification_request: VerificationCodeRequest = Faker.fake();
-        verification_request.created_at = Utc::now().checked_sub_signed(TimeDelta::minutes(14)).unwrap();
+        verification_request.created_at = Utc::now()
+            .checked_sub_signed(TimeDelta::minutes(14))
+            .unwrap();
         assert!(!verification_request.is_expired());
 
-        verification_request.created_at = Utc::now().checked_sub_signed(TimeDelta::minutes(16)).unwrap();
+        verification_request.created_at = Utc::now()
+            .checked_sub_signed(TimeDelta::minutes(16))
+            .unwrap();
         assert!(verification_request.is_expired());
     }
 }

--- a/src/routes/account/model.rs
+++ b/src/routes/account/model.rs
@@ -13,6 +13,29 @@ pub struct Account {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(FromRow)]
+pub struct VerificationCodeRequest {
+    pub id: uuid::Uuid,
+    pub account_id: uuid::Uuid,
+    pub cyphertext: String,
+    pub status: VerificationCodeRequestStatus,
+    // This field is automatically set at creation at the database level
+    pub created_at: DateTime<Utc>,
+    // This field is automatically updated at the database level
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(sqlx::Type)]
+#[sqlx(
+    type_name = "verification_code_request_status",
+    rename_all = "lowercase"
+)]
+pub enum VerificationCodeRequestStatus {
+    Active,
+    Cancelled,
+    Confirmed,
+}
+
 impl Account {
     /// Update the password hash of an account
     ///

--- a/src/routes/account/model.rs
+++ b/src/routes/account/model.rs
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn test_confirm() {
+    fn test_confirm_verification_request() {
         let mut verification_request: VerificationCodeRequest = Faker.fake();
         verification_request.confirm();
         match verification_request.status {
@@ -136,5 +136,15 @@ mod tests {
                 panic!("Expected `confirmed` verification request")
             }
         };
+    }
+
+    #[test]
+    fn test_verification_request_expiration() {
+        let mut verification_request: VerificationCodeRequest = Faker.fake();
+        verification_request.created_at = Utc::now().checked_sub_signed(TimeDelta::minutes(14)).unwrap();
+        assert!(!verification_request.is_expired());
+
+        verification_request.created_at = Utc::now().checked_sub_signed(TimeDelta::minutes(16)).unwrap();
+        assert!(verification_request.is_expired());
     }
 }

--- a/src/routes/account/model.rs
+++ b/src/routes/account/model.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeDelta, Utc};
 use sqlx::{prelude::FromRow, types::uuid};
 
 #[derive(FromRow)]
@@ -11,6 +11,21 @@ pub struct Account {
     pub created_at: DateTime<Utc>,
     // This field is automatically updated at the database level
     pub updated_at: DateTime<Utc>,
+}
+
+impl Account {
+    /// Update the password hash of an account
+    ///
+    /// # Arguments
+    /// * `password_hash` - Updated password hash
+    pub fn update_password_hash(&mut self, password_hash: String) {
+        self.password_hash = password_hash;
+    }
+
+    /// Verify the email of an account
+    pub fn verify_email(&mut self) {
+        self.email_verified = true;
+    }
 }
 
 #[derive(FromRow)]
@@ -36,18 +51,15 @@ pub enum VerificationCodeRequestStatus {
     Confirmed,
 }
 
-impl Account {
-    /// Update the password hash of an account
-    ///
-    /// # Arguments
-    /// * `password_hash` - Updated password hash
-    pub fn update_password_hash(&mut self, password_hash: String) {
-        self.password_hash = password_hash;
+impl VerificationCodeRequest {
+    pub fn confirm(&mut self) {
+        self.status = VerificationCodeRequestStatus::Confirmed
     }
 
-    /// Verify the email of an account
-    pub fn verify_email(&mut self) {
-        self.email_verified = true;
+    pub fn is_expired(&self) -> bool {
+        Utc::now()
+            .signed_duration_since(self.created_at)
+            .gt(&TimeDelta::minutes(15))
     }
 }
 

--- a/src/routes/account/repository.rs
+++ b/src/routes/account/repository.rs
@@ -11,7 +11,7 @@ pub trait AccountRepository: Send + Sync {
     /// * `email` - Email of the account
     ///
     /// # Errors
-    /// - `Unclassified`: fallback error type
+    /// * `Unclassified` - fallback error type
     async fn get_account_by_email(
         &self,
         email: &str,
@@ -23,7 +23,7 @@ pub trait AccountRepository: Send + Sync {
     /// * `account` - Updated account,
     ///
     /// # Errors
-    /// - `Unclassified`: fallback error type
+    /// * `Unclassified` - fallback error type
     async fn update_account(&self, account: &Account) -> Result<Account, AccountRepositoryError>;
 
     /// Create an account
@@ -33,7 +33,7 @@ pub trait AccountRepository: Send + Sync {
     /// * `password_hash` - Hash of the password
     ///
     /// # Errors
-    /// - `Unclassified`: fallback error type
+    /// * `Unclassified` - fallback error type
     async fn create_account(
         &self,
         email: &str,
@@ -47,11 +47,35 @@ pub trait AccountRepository: Send + Sync {
     /// * `code_cyphertext` - cyphertext of the verification code
     ///
     /// # Errors
-    /// - `Unclassified`: fallback error type
-    async fn cancel_last_and_create_code_request(
+    /// * `Unclassified` - fallback error type
+    async fn cancel_last_and_create_verification_request(
         &self,
         account_id: uuid::Uuid,
         code_cyphertext: &str,
+    ) -> Result<VerificationCodeRequest, AccountRepositoryError>;
+
+    /// Get the active verification request for an account
+    ///
+    /// # Arguments
+    /// * `account_id` - ID of the account,
+    ///
+    /// # Errors
+    /// * `Unclassified` - fallback error type
+    async fn get_active_validation_request(
+        &self,
+        account_id: uuid::Uuid,
+    ) -> Result<Option<VerificationCodeRequest>, AccountRepositoryError>;
+
+    /// Update a verification request
+    ///
+    /// # Arguments
+    /// * `verification_request` - Updated verification request
+    ///
+    /// # Errors
+    /// * `Unclassified` - fallback error type
+    async fn update_verification_request(
+        &self,
+        verification_request: &VerificationCodeRequest,
     ) -> Result<VerificationCodeRequest, AccountRepositoryError>;
 }
 
@@ -161,7 +185,7 @@ impl AccountRepository for PostgresAccountRepository {
         .map_err(|e| anyhow::Error::from(e).into())
     }
 
-    async fn cancel_last_and_create_code_request(
+    async fn cancel_last_and_create_verification_request(
         &self,
         account_id: uuid::Uuid,
         cyphertext: &str,
@@ -197,6 +221,60 @@ impl AccountRepository for PostgresAccountRepository {
         )
         .bind(account_id)
         .bind(cyphertext)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| anyhow::Error::from(e).into())
+    }
+
+    async fn get_active_validation_request(
+        &self,
+        account_id: uuid::Uuid,
+    ) -> Result<Option<VerificationCodeRequest>, AccountRepositoryError> {
+        match sqlx::query_as::<_, VerificationCodeRequest>(
+            r#"
+                SELECT
+                    id,
+                    account_id,
+                    cyphertext,
+                    status,
+                    created_at,
+                    updated_at
+                FROM "verification_code_request"
+                WHERE "account_id" = $1 AND "status" = 'active'
+            "#,
+        )
+        .bind(account_id)
+        .fetch_one(&self.pool)
+        .await
+        {
+            Ok(v) => Ok(Some(v)),
+            Err(e) => match e {
+                sqlx::Error::RowNotFound => Ok(None),
+                other => return Err(anyhow::Error::from(other).into()),
+            },
+        }
+    }
+
+    async fn update_verification_request(
+        &self,
+        verification_request: &VerificationCodeRequest,
+    ) -> Result<VerificationCodeRequest, AccountRepositoryError> {
+        sqlx::query_as::<_, VerificationCodeRequest>(
+            r#"
+            UPDATE "verification_code_request"
+            SET "status" = $2
+            WHERE "id" = $1
+            RETURNING 
+                id,
+                account_id,
+                cyphertext,
+                status,
+                created_at,
+                updated_at
+        "#,
+        )
+        .bind(verification_request.id)
+        .bind(&verification_request.status)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| anyhow::Error::from(e).into())

--- a/src/routes/account/verification_code_strategy.rs
+++ b/src/routes/account/verification_code_strategy.rs
@@ -1,0 +1,109 @@
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier, password_hash::Salt};
+use base64::prelude::*;
+use hmac::{Hmac, Mac};
+use rand::prelude::*;
+use rand_chacha::ChaCha20Rng;
+use sha3::Sha3_256;
+
+#[derive(Debug)]
+pub struct VerificationCodeStategy;
+
+impl VerificationCodeStategy {
+    /// Generate a verification code linked to an email with its encryption
+    ///
+    /// The code is a random 8 digits number.
+    /// An encryption of the code is performed for later verification:
+    ///     1. a random 16 bytes (128 bits) salt is generated,
+    ///     2. a key is derived using the Argon2id scheme with the salt and the code as password,
+    ///     3. a mac is computed using HMAC(key hash, email, SHA3-256)
+    ///
+    /// # Arguments
+    /// * `email` - email to link the verification code to
+    pub fn generate_verification_code(email: &str) -> Result<(u32, String), anyhow::Error> {
+        let mut salt = [0u8; 16];
+        let mut rng = ChaCha20Rng::from_os_rng();
+        rng.fill_bytes(&mut salt);
+        let base64_salt = BASE64_STANDARD_NO_PAD.encode(salt);
+        let argon_salt = Salt::from_b64(&base64_salt).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let mut code: u32 = rng.random();
+        // Code is only 8 numbers
+        code %= 100_000_000;
+        let key = Argon2::default()
+            .hash_password(&code.to_le_bytes(), argon_salt)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let key_hash = key
+            .hash
+            .ok_or(anyhow::anyhow!("Unable to extract hash from key"))?;
+
+        let mut hmac: Hmac<Sha3_256> = Hmac::new_from_slice(key_hash.as_bytes())?;
+        hmac.update(email.as_bytes());
+        let mac = hmac.finalize().into_bytes();
+
+        // Mac is 32 bytes
+        // Key is a string of 97 bytes
+        let mut cyphertext = [0u8; 129];
+        cyphertext[..97].copy_from_slice(key.serialize().as_bytes());
+        cyphertext[97..].copy_from_slice(&mac);
+
+        Ok((code, BASE64_STANDARD_NO_PAD.encode(cyphertext)))
+    }
+
+    /// Verify a verification code.
+    ///
+    /// The code is verified against the Argon2id generated key.
+    /// The mail is verified against the HMAC of the generated key hash, the email and using SHA3-256
+    ///
+    /// # Arguments
+    /// * `code` - 8 digits secret code,
+    /// * `email` - email to which the code is linked,
+    /// * `cyphertext` - the compactified elements of the encryption of the code, previously generated
+    pub fn verify_verification_code(
+        code: u32,
+        email: &str,
+        cyphertext: &str,
+    ) -> Result<(), anyhow::Error> {
+        let cyphertext_bytes = BASE64_STANDARD_NO_PAD.decode(cyphertext)?;
+        if cyphertext_bytes.len() != 129 {
+            return Err(anyhow::anyhow!(
+                "Expected 129 bytes length string, got {}",
+                cyphertext_bytes.len()
+            ));
+        }
+        let (key, mac) = cyphertext_bytes.split_at(97);
+
+        let password_hash =
+            PasswordHash::new(std::str::from_utf8(key)?).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        Argon2::default()
+            .verify_password(&code.to_le_bytes(), &password_hash)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let mut hmac: Hmac<Sha3_256> = Hmac::new_from_slice(
+            password_hash
+                .hash
+                .ok_or(anyhow::anyhow!("Unable to extract hash from key"))?
+                .as_bytes(),
+        )?;
+        hmac.update(email.as_bytes());
+        hmac.verify_slice(mac)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fake::{Fake, faker};
+
+    use super::*;
+
+    #[test]
+    fn test_verification_code_encryption() {
+        let email: String = faker::internet::en::SafeEmail().fake();
+        let (code, cyphertext) =
+            VerificationCodeStategy::generate_verification_code(&email).unwrap();
+        assert!(
+            VerificationCodeStategy::verify_verification_code(code, &email, &cyphertext).is_ok()
+        );
+    }
+}

--- a/src/routes/account/verification_code_strategy.rs
+++ b/src/routes/account/verification_code_strategy.rs
@@ -49,7 +49,7 @@ impl VerificationCodeStategy {
         Ok((code, BASE64_STANDARD_NO_PAD.encode(cyphertext)))
     }
 
-    /// Verify a verification code.
+    /// Verify a verification code, returns true if code is correct, false otherwise
     ///
     /// The code is verified against the Argon2id generated key.
     /// The mail is verified against the HMAC of the generated key hash, the email and using SHA3-256
@@ -62,7 +62,7 @@ impl VerificationCodeStategy {
         code: u32,
         email: &str,
         cyphertext: &str,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<bool, anyhow::Error> {
         let cyphertext_bytes = BASE64_STANDARD_NO_PAD.decode(cyphertext)?;
         if cyphertext_bytes.len() != 129 {
             return Err(anyhow::anyhow!(
@@ -85,9 +85,8 @@ impl VerificationCodeStategy {
                 .as_bytes(),
         )?;
         hmac.update(email.as_bytes());
-        hmac.verify_slice(mac)?;
 
-        Ok(())
+        Ok(hmac.verify_slice(mac).is_ok())
     }
 }
 

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,15 +3,21 @@ use std::sync::Arc;
 use axum::{Json, Router, http::StatusCode, response::IntoResponse, routing::get};
 use serde::{Deserialize, Serialize};
 mod account;
-use super::Config;
+
+use super::{Config, third_party::MailingService};
 pub use account::{
     AccountRepository, AccountResponse, PostgresAccountRepository, SignupPayload,
     VerifyEmailPayload,
 };
 
-pub fn app_router(_: &Config, account_repository: impl AccountRepository + 'static) -> Router {
+pub fn app_router(
+    _: &Config,
+    account_repository: impl AccountRepository + 'static,
+    mailing_service: impl MailingService + 'static,
+) -> Router {
     let app_state = AppState {
         account_repository: Arc::new(account_repository),
+        mailing_service: Arc::new(mailing_service),
     };
     Router::new()
         .nest("/accounts", account::account_router())
@@ -23,6 +29,7 @@ pub fn app_router(_: &Config, account_repository: impl AccountRepository + 'stat
 #[derive(Clone)]
 pub struct AppState {
     account_repository: Arc<dyn AccountRepository>,
+    mailing_service: Arc<dyn MailingService>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/third_party/mod.rs
+++ b/src/third_party/mod.rs
@@ -1,0 +1,16 @@
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait MailingService: Send + Sync {
+    async fn send_email(&self, email: &str, content: &str) -> Result<(), anyhow::Error>;
+}
+
+#[derive(Debug, Clone)]
+pub struct ToBeImplementedMailingService;
+
+#[async_trait]
+impl MailingService for ToBeImplementedMailingService {
+    async fn send_email(&self, _email: &str, _content: &str) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+}

--- a/src/third_party/mod.rs
+++ b/src/third_party/mod.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use tracing::warn;
 
 #[async_trait]
 pub trait MailingService: Send + Sync {
@@ -10,7 +11,8 @@ pub struct ToBeImplementedMailingService;
 
 #[async_trait]
 impl MailingService for ToBeImplementedMailingService {
-    async fn send_email(&self, _email: &str, _content: &str) -> Result<(), anyhow::Error> {
+    async fn send_email(&self, _email: &str, content: &str) -> Result<(), anyhow::Error> {
+        warn!("THIS LOG IS MEANT TO BE DELETED IN THE FUTURE -- Email content is {content}");
         Ok(())
     }
 }

--- a/tests/account_signup_test.rs
+++ b/tests/account_signup_test.rs
@@ -51,7 +51,11 @@ async fn test_account_email_verification() {
         .post(format!("{}/accounts/verify-email", &test_state.server_url))
         .json(&VerifyEmailPayload {
             email: email.clone(),
-            code: (1..100_000_000).fake(),
+            code: test_state
+                .mailing_service
+                .get_verification_code(&email)
+                .unwrap()
+                .unwrap(),
         })
         .send()
         .await
@@ -80,7 +84,11 @@ async fn test_forbidden_signup_once_verified() {
         .post(format!("{}/accounts/verify-email", &test_state.server_url))
         .json(&VerifyEmailPayload {
             email: email.clone(),
-            code: (1..100_000_000).fake(),
+            code: test_state
+                .mailing_service
+                .get_verification_code(&email)
+                .unwrap()
+                .unwrap(),
         })
         .send()
         .await
@@ -91,7 +99,11 @@ async fn test_forbidden_signup_once_verified() {
             .post(format!("{}/accounts/verify-email", &test_state.server_url))
             .json(&VerifyEmailPayload {
                 email: email.clone(),
-                code: (1..100_000_000).fake(),
+                code: test_state
+                    .mailing_service
+                    .get_verification_code(&email)
+                    .unwrap()
+                    .unwrap(),
             })
             .send()
             .await


### PR DESCRIPTION
# Summary

The verify email is completed:
- at signup time, a code is generated alongside its encrypted version, the encrypted version is stored in database while the the code should be sent to the account email. The sending is for now non implemented, there is a fake implementation for a mailing service for this,
- at verify email, the code is in the input payload and is checked against the cyphertext in database.

Additionally:
- an account can only have one active verification request at a time,
- if an account signs up again, it cancels the previous verification request and creates a new one,
- a verification request is only valid for 15 minutes.

In terms of cryptography:
- The code is a 8 digits number, it will be changed in the future,
- we derive a key using the Argon2id algorithm, we generate a random salt for that,
- we derive a mac as HMAC(derived key hash, email, SHA3-256),
- the cyphertext is actually the derived key, formatted by the Argon2id algorithm.